### PR TITLE
Implement encoding.Text(M|Unm)arshaler

### DIFF
--- a/bytefmt.go
+++ b/bytefmt.go
@@ -277,14 +277,14 @@ func (s *Size) Scan(value interface{}) error {
 
 	case string:
 		size, err := Parse(v)
-		if s != nil {
+		if size != nil {
 			*s = *size
 		}
 		return err
 
 	case []byte:
 		size, err := Parse(string(v))
-		if s != nil {
+		if size != nil {
 			*s = *size
 		}
 		return err

--- a/bytefmt.go
+++ b/bytefmt.go
@@ -93,12 +93,12 @@ func Parse(s string) (*Size, error) {
 	if err != nil {
 		return nil, fmt.Errorf("can't convert %q to size: %w", s, err)
 	}
-	return &size, nil
+	return size, nil
 }
 
-func parse(s string) (Size, error) {
+func parse(s string) (*Size, error) {
 	if len(s) == 0 {
-		return Size{}, errors.New("empty string")
+		return nil, errors.New("empty string")
 	}
 
 	pos, end := 0, len(s)
@@ -135,7 +135,7 @@ func parse(s string) (Size, error) {
 
 	// Normalize whole and fractional parts.
 	if len(whole) == 0 && len(frac) == 0 {
-		return Size{}, errors.New("must start with a number")
+		return nil, errors.New("must start with a number")
 	}
 	if len(whole) == 0 {
 		whole = "0"
@@ -150,7 +150,7 @@ func parse(s string) (Size, error) {
 	// Everything remaining must be the unit suffix.
 	exp, base, err := parseSuffix(s[pos:end])
 	if err != nil {
-		return Size{}, err
+		return nil, err
 	}
 
 	// To avoid precision loss for large numbers, calculate size in big decimal.
@@ -184,10 +184,10 @@ func parse(s string) (Size, error) {
 	}
 
 	if !val.IsInt64() {
-		return Size{}, errors.New("value exceeds 64 bits")
+		return nil, errors.New("value exceeds 64 bits")
 	}
 
-	return Size{bytes: val.Int64(), Base: base}, nil
+	return &Size{bytes: val.Int64(), Base: base}, nil
 }
 
 // String returns the formatted quantity scaled to the largest exact base unit.

--- a/bytefmt.go
+++ b/bytefmt.go
@@ -220,6 +220,21 @@ func (s *Size) String() string {
 	return string(result)
 }
 
+// MarshalText implements the encoding.TextMarshaler interface.
+func (s Size) MarshalText() ([]byte, error) {
+	return []byte(s.String()), nil
+}
+
+// UnmarshalText implements the encoding.TextUnmarshaler interface.
+func (s *Size) UnmarshalText(value []byte) error {
+	size, err := Parse(string(value))
+	*s = size
+	if err != nil {
+		return fmt.Errorf("can't decode %q as bytefmt.Size: %w", string(value), err)
+	}
+	return nil
+}
+
 // MarshalJSON implements the json.Marshaler interface.
 func (s Size) MarshalJSON() ([]byte, error) {
 	return []byte(strconv.Quote(s.String())), nil

--- a/bytefmt.go
+++ b/bytefmt.go
@@ -228,11 +228,10 @@ func (s Size) MarshalText() ([]byte, error) {
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (s *Size) UnmarshalText(value []byte) error {
 	size, err := Parse(string(value))
-	if err != nil {
-		return err
+	if size != nil {
+		*s = *size
 	}
-	*s = *size
-	return nil
+	return err
 }
 
 // MarshalJSON implements the json.Marshaler interface.
@@ -256,11 +255,10 @@ func (s *Size) UnmarshalJSON(value []byte) error {
 	}
 
 	size, err := Parse(str)
-	if err != nil {
-		return err
+	if size != nil {
+		*s = *size
 	}
-	*s = *size
-	return nil
+	return err
 }
 
 // Value implements the sql.Valuer interface. It always produces a string.


### PR DESCRIPTION
This is necessary to marshal to/from YAML and plain text.